### PR TITLE
Improve marshaller efficiency

### DIFF
--- a/src/main/java/io/github/alvinchiu/gstreamgate/marshaller/PassthroughMarshaller.java
+++ b/src/main/java/io/github/alvinchiu/gstreamgate/marshaller/PassthroughMarshaller.java
@@ -1,14 +1,9 @@
 package io.github.alvinchiu.gstreamgate.marshaller;
 
-import com.google.common.io.ByteStreams;
 import io.grpc.MethodDescriptor;
-import io.grpc.Status;
-import io.grpc.StatusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -23,55 +18,21 @@ public class PassthroughMarshaller implements MethodDescriptor.Marshaller<InputS
     public InputStream parse(InputStream stream) {
         if (stream == null) {
             logger.warn("Received null input stream for parsing");
-            return new ByteArrayInputStream(new byte[0]);
+            return InputStream.nullInputStream();
         }
 
-        try {
-            byte[] bytes = ByteStreams.toByteArray(stream);
-            logger.debug("Parsed input stream, size: " + bytes.length + " bytes");
-            return new ByteArrayInputStream(bytes);
-        } catch (IOException e) {
-            logger.error("IO error parsing input stream: " + e.getMessage());
-            throw new RuntimeException(
-                    new StatusException(Status.INTERNAL
-                            .withDescription("IO error parsing input stream: " + e.getMessage())
-                            .withCause(e))
-            );
-        } catch (Exception e) {
-            logger.error("Unexpected error parsing input stream: " + e.getMessage());
-            throw new RuntimeException(
-                    new StatusException(Status.UNKNOWN
-                            .withDescription("Unexpected error parsing input stream: " + e.getMessage())
-                            .withCause(e))
-            );
-        }
+        logger.debug("Passing through input stream without copying");
+        return stream;
     }
 
     @Override
     public InputStream stream(InputStream value) {
         if (value == null) {
             logger.warn("Received null input stream for streaming");
-            return new ByteArrayInputStream(new byte[0]);
+            return InputStream.nullInputStream();
         }
 
-        try {
-            byte[] bytes = ByteStreams.toByteArray(value);
-            logger.debug("Streamed input stream, size: " + bytes.length + " bytes");
-            return new ByteArrayInputStream(bytes);
-        } catch (IOException e) {
-            logger.error("IO error streaming input stream: " + e.getMessage());
-            throw new RuntimeException(
-                    new StatusException(Status.INTERNAL
-                            .withDescription("IO error streaming input stream: " + e.getMessage())
-                            .withCause(e))
-            );
-        } catch (Exception e) {
-            logger.error("Unexpected error streaming input stream: " + e.getMessage());
-            throw new RuntimeException(
-                    new StatusException(Status.UNKNOWN
-                            .withDescription("Unexpected error streaming input stream: " + e.getMessage())
-                            .withCause(e))
-            );
-        }
+        logger.debug("Streaming input stream without copying");
+        return value;
     }
 }

--- a/src/test/java/io/github/alvinchiu/gstreamgate/marshaller/PassthroughMarshallerTest.java
+++ b/src/test/java/io/github/alvinchiu/gstreamgate/marshaller/PassthroughMarshallerTest.java
@@ -1,6 +1,4 @@
 import io.github.alvinchiu.gstreamgate.marshaller.PassthroughMarshaller;
-import io.grpc.Status;
-import io.grpc.StatusException;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -45,34 +43,25 @@ class PassthroughMarshallerTest {
     }
 
     @Test
-    void parse_ioExceptionWrapsInRuntimeException() {
+    void parse_doesNotReadInputStream() {
         InputStream failing = new InputStream() {
             @Override
             public int read() throws IOException {
                 throw new IOException("boom");
             }
         };
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> marshaller.parse(failing));
-        assertStatusException(ex, "IO error parsing input stream: boom");
+        assertSame(failing, marshaller.parse(failing));
     }
 
     @Test
-    void stream_ioExceptionWrapsInRuntimeException() {
+    void stream_doesNotReadInputStream() {
         InputStream failing = new InputStream() {
             @Override
             public int read() throws IOException {
                 throw new IOException("fail");
             }
         };
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> marshaller.stream(failing));
-        assertStatusException(ex, "IO error streaming input stream: fail");
-    }
-
-    private void assertStatusException(RuntimeException ex, String expectedDescription) {
-        assertTrue(ex.getCause() instanceof StatusException);
-        StatusException se = (StatusException) ex.getCause();
-        assertEquals(Status.Code.INTERNAL, se.getStatus().getCode());
-        assertEquals(expectedDescription, se.getStatus().getDescription());
-        assertTrue(se.getCause() instanceof IOException);
+        assertSame(failing, marshaller.stream(failing));
     }
 }
+


### PR DESCRIPTION
## Summary
- refactor `PassthroughMarshaller` to avoid copying streams
- update tests for new behaviour

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_683ff8547a088328b03348c25c224946