### PR TITLE
Add integration tests for new auth and proxy APIs

### DIFF
--- a/src/test/java/io/github/alvinchiu/gstreamgate/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/io/github/alvinchiu/gstreamgate/controller/AuthControllerIntegrationTest.java
@@ -1,0 +1,63 @@
+package io.github.alvinchiu.gstreamgate.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(properties = "grpc.proxy.server.port=0", webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("development")
+class AuthControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String baseUrl(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    @Test
+    void loginAndFetchCurrentUser() {
+        String username = "ituser" + System.currentTimeMillis();
+
+        Map<String, String> register = new HashMap<>();
+        register.put("username", username);
+        register.put("password", "pass");
+        register.put("email", username + "@ex.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, String>> regEntity = new HttpEntity<>(register, headers);
+        ResponseEntity<Map> regResp = restTemplate.postForEntity(baseUrl("/api/auth/register"), regEntity, Map.class);
+        assertEquals(HttpStatus.CREATED, regResp.getStatusCode());
+
+        Map<String, String> login = new HashMap<>();
+        login.put("username", username);
+        login.put("password", "pass");
+
+        HttpEntity<Map<String, String>> loginEntity = new HttpEntity<>(login, headers);
+        ResponseEntity<Map> loginResp = restTemplate.postForEntity(baseUrl("/api/auth/login"), loginEntity, Map.class);
+        assertEquals(HttpStatus.OK, loginResp.getStatusCode());
+        String token = (String) loginResp.getBody().get("token");
+        assertNotNull(token);
+
+        HttpHeaders authHeaders = new HttpHeaders();
+        authHeaders.setBearerAuth(token);
+        HttpEntity<Void> entity = new HttpEntity<>(authHeaders);
+        ResponseEntity<Map> meResp = restTemplate.exchange(baseUrl("/api/auth/me"), HttpMethod.GET, entity, Map.class);
+        assertEquals(HttpStatus.OK, meResp.getStatusCode());
+        assertEquals(username, meResp.getBody().get("username"));
+        assertEquals(true, meResp.getBody().get("authenticated"));
+    }
+}

--- a/src/test/java/io/github/alvinchiu/gstreamgate/controller/GrpcProxyControllerIntegrationTest.java
+++ b/src/test/java/io/github/alvinchiu/gstreamgate/controller/GrpcProxyControllerIntegrationTest.java
@@ -1,0 +1,75 @@
+package io.github.alvinchiu.gstreamgate.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(properties = "grpc.proxy.server.port=0", webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("development")
+class GrpcProxyControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String baseUrl(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private String loginAsUser() {
+        String username = "itest" + System.currentTimeMillis();
+
+        Map<String, String> register = new HashMap<>();
+        register.put("username", username);
+        register.put("password", "pass");
+        register.put("email", username + "@ex.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, String>> regEntity = new HttpEntity<>(register, headers);
+        ResponseEntity<Map> regResp = restTemplate.postForEntity(baseUrl("/api/auth/register"), regEntity, Map.class);
+        assertEquals(HttpStatus.CREATED, regResp.getStatusCode());
+
+        Map<String, String> login = new HashMap<>();
+        login.put("username", username);
+        login.put("password", "pass");
+
+        HttpEntity<Map<String, String>> loginEntity = new HttpEntity<>(login, headers);
+        ResponseEntity<Map> resp = restTemplate.postForEntity(baseUrl("/api/auth/login"), loginEntity, Map.class);
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        return (String) resp.getBody().get("token");
+    }
+
+    @Test
+    void listEnabledProxiesWithAuth() {
+        String token = loginAsUser();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<List<Map<String, Object>>> resp = restTemplate.exchange(
+                baseUrl("/api/proxy/enabled"),
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        List<Map<String, Object>> proxies = resp.getBody();
+        assertNotNull(proxies);
+        assertFalse(proxies.isEmpty());
+    }
+}

--- a/src/test/java/io/github/alvinchiu/gstreamgate/security/JwtUtilTest.java
+++ b/src/test/java/io/github/alvinchiu/gstreamgate/security/JwtUtilTest.java
@@ -1,0 +1,38 @@
+package io.github.alvinchiu.gstreamgate.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtUtilTest {
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jwtUtil = new JwtUtil();
+        // Inject secret and expiration via reflection
+        Field secretField = JwtUtil.class.getDeclaredField("secret");
+        secretField.setAccessible(true);
+        secretField.set(jwtUtil, "TestSecretKeyThatIsLongEnoughForHS256Algorithm");
+
+        Field expField = JwtUtil.class.getDeclaredField("expiration");
+        expField.setAccessible(true);
+        expField.set(jwtUtil, 3600000L); // 1 hour
+    }
+
+    @Test
+    void generateAndValidateToken() {
+        UserDetails user = User.withUsername("testuser").password("password").roles("USER").build();
+        String token = jwtUtil.generateToken(user);
+
+        assertNotNull(token);
+        assertEquals("testuser", jwtUtil.extractUsername(token));
+        assertTrue(jwtUtil.validateToken(token, user));
+        assertTrue(jwtUtil.isTokenValid(token));
+    }
+}

--- a/src/test/java/io/github/alvinchiu/gstreamgate/service/AuthServiceTest.java
+++ b/src/test/java/io/github/alvinchiu/gstreamgate/service/AuthServiceTest.java
@@ -1,0 +1,95 @@
+package io.github.alvinchiu.gstreamgate.service;
+
+import io.github.alvinchiu.gstreamgate.entity.User;
+import io.github.alvinchiu.gstreamgate.repository.UserRepository;
+import io.github.alvinchiu.gstreamgate.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest {
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private JwtUtil jwtUtil;
+    private ApplicationContext applicationContext;
+    private AuthenticationManager authenticationManager;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        jwtUtil = mock(JwtUtil.class);
+        applicationContext = mock(ApplicationContext.class);
+        authenticationManager = mock(AuthenticationManager.class);
+
+        when(applicationContext.getBean(AuthenticationManager.class)).thenReturn(authenticationManager);
+
+        authService = new AuthService(userRepository, passwordEncoder, jwtUtil, applicationContext);
+    }
+
+    @Test
+    void loginReturnsTokenAndUpdatesLastLogin() throws Exception {
+        User user = new User("user","pass","user@example.com");
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        when(jwtUtil.generateToken(user)).thenReturn("token123");
+
+        Map<String, Object> result = authService.login("user", "pass");
+
+        assertEquals("token123", result.get("token"));
+        assertEquals("user", result.get("username"));
+        verify(userRepository).updateLastLogin(eq("user"), any(Date.class));
+    }
+
+    @Test
+    void logoutAddsTokenToBlacklist() {
+        when(jwtUtil.isTokenValid("tkn")).thenReturn(true);
+        when(jwtUtil.extractUsername("tkn")).thenReturn("user");
+
+        Map<String, Object> result = authService.logout("tkn");
+
+        assertTrue(authService.isTokenBlacklisted("tkn"));
+        assertEquals("Logout successful", result.get("message"));
+    }
+
+    @Test
+    void registerSavesNewUser() {
+        when(userRepository.existsByUsername("user")).thenReturn(false);
+        when(userRepository.existsByEmail("user@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("pass")).thenReturn("hashed");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Map<String, Object> result = authService.register("user","pass","user@example.com");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertEquals("hashed", captor.getValue().getPassword());
+        assertEquals("User registered successfully", result.get("message"));
+    }
+
+    @Test
+    void validateTokenHandlesValidAndInvalid() {
+        when(jwtUtil.isTokenValid("good")).thenReturn(true);
+        when(jwtUtil.extractUsername("good")).thenReturn("user");
+        when(jwtUtil.isTokenValid("bad")).thenReturn(false);
+
+        Map<String, Object> ok = authService.validateToken("good");
+        Map<String, Object> bad = authService.validateToken("bad");
+
+        assertEquals(true, ok.get("valid"));
+        assertEquals("user", ok.get("username"));
+        assertEquals(false, bad.get("valid"));
+    }
+}


### PR DESCRIPTION
## Summary
- integration test login and /api/auth/me flow
- check /api/proxy/enabled endpoint using authenticated user

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684130dea8588328a3b7fbb9629e0db5